### PR TITLE
Remove JSON.stringify for login request

### DIFF
--- a/src/modules/auth/providers/auth/auth.provider.ts
+++ b/src/modules/auth/providers/auth/auth.provider.ts
@@ -140,7 +140,7 @@ export class AuthProvider {
   }
 
   private async sendLoginRequest(requestBody: any): Promise<Auth> {
-    const data = await this.http.post<any>(this.authConfig.loginUrl, JSON.stringify(requestBody)).toPromise();
+    const data = await this.http.post<any>(this.authConfig.loginUrl, requestBody).toPromise();
     return this.authConfig.convertToAuthType(data);
   }
 


### PR DESCRIPTION
## Description
Angular guesses the `Content-Type` from the `requestBody`. If you use `JSON.stringify`, it will guess `text/plain`. If you pass the javascript object it will it to `application/json` (that what we want).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
